### PR TITLE
Latest version number semantics

### DIFF
--- a/lib/versioncake/action_view/versions.rb
+++ b/lib/versioncake/action_view/versions.rb
@@ -65,7 +65,7 @@ module ActionView
         else
           @@supported_version_numbers = Array.wrap(val)
         end
-        @@supported_version_numbers.reverse!
+        @@supported_version_numbers.sort!.reverse!
       end
 
       def self.supported_versions(requested_version_number=nil)


### PR DESCRIPTION
The documentation says that if an API version is not specified then version cake will fall back to the 'latest' version. My expectation is that the latest version means the highest version number available (it's currently the last item in the 'view_versions' configuration parameter array). Adding a sort!
