### PR TITLE
Add Default Version override

### DIFF
--- a/lib/versioncake/configuration.rb
+++ b/lib/versioncake/configuration.rb
@@ -11,6 +11,9 @@ module VersionCake
     mattr_accessor :extraction_strategies
     self.extraction_strategies = [VersionCake::QueryParameterStrategy.new]
 
+    mattr_accessor :default_version
+    self.default_version = nil
+
     def self.extraction_strategy=(val)
       @@extraction_strategies.clear
       Array.wrap(val).each do |configured_strategy|

--- a/lib/versioncake/railtie.rb
+++ b/lib/versioncake/railtie.rb
@@ -14,6 +14,10 @@ class ActionViewVersions < Rails::Railtie
       if app.config.respond_to?(:view_version_string)
         VersionCake::ExtractionStrategy.version_string = app.config.view_version_string
       end
+
+      if app.config.respond_to?(:default_version)
+        VersionCake::Configuration.default_version = app.config.default_version
+      end
     end
   end
 end

--- a/lib/versioncake/versioned_request.rb
+++ b/lib/versioncake/versioned_request.rb
@@ -25,7 +25,7 @@ module VersionCake
     def extract_version(request)
       @extracted_version = apply_strategies(request)
       if @extracted_version.nil?
-        @version = VersionCake::Configuration.latest_version
+        @version = VersionCake::Configuration.default_version || VersionCake::Configuration.latest_version
       elsif VersionCake::Configuration.supports_version? @extracted_version
         @version = @extracted_version
       elsif @extracted_version > VersionCake::Configuration.latest_version

--- a/test/functional/renders_controller_test.rb
+++ b/test/functional/renders_controller_test.rb
@@ -33,9 +33,16 @@ class RendersControllerTest < ActionController::TestCase
     assert !@controller.is_latest_version
   end
 
-  test "exposes the derived version when the version is not set" do
+  test "exposes the derived version when the version is not set and no default" do
     get :index
     assert_equal 3, @controller.derived_version
+  end
+
+  test "exposes the default version when the version is not set default is set" do
+    VersionCake::Configuration.default_version = 1
+    get :index
+    assert_equal 1, @controller.derived_version
+    VersionCake::Configuration.default_version = nil
   end
 
   test "requested version is blank when the version is not set" do
@@ -141,6 +148,15 @@ class AcceptHeaderStrategyTest < ActionController::TestCase
     get :index
     assert_equal @response.body, "index.v2.html.erb"
   end
+
+  test "render the default version version of the partial" do
+    VersionCake::Configuration.default_version = 1
+    @controller.request.stubs(:headers).returns({"HTTP_ACCEPT" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8;api_version=abc"})
+    get :index
+    assert_equal @response.body, "index.v1.html.erb"
+    VersionCake::Configuration.default_version = nil
+  end
+
 end
 
 class CustomStrategyTest < ActionController::TestCase


### PR DESCRIPTION
The adds a config option to allow a default version to be set in the case of a request having no version information. If the default value is not set it reverts back to the previous functionality of choosing the latest version.
