### PR TITLE
Convert to_s when extracting a query parameter

### DIFF
--- a/lib/versioncake/strategies/query_parameter_strategy.rb
+++ b/lib/versioncake/strategies/query_parameter_strategy.rb
@@ -3,7 +3,7 @@ module VersionCake
 
     def execute(request)
       if request.query_parameters.key? @@version_string.to_sym
-        request.query_parameters[@@version_string.to_sym]
+        request.query_parameters[@@version_string.to_sym].to_s
       end
     end
 

--- a/test/unit/strategies/extraction_strategy_test.rb
+++ b/test/unit/strategies/extraction_strategy_test.rb
@@ -7,7 +7,7 @@ class ExtractionStrategyTest < ActiveSupport::TestCase
     end
   end
 
-  test "extract will convert the the result to integer" do
+  test "extract will convert the result to integer" do
     class TestStrategy < VersionCake::ExtractionStrategy
       def execute(request); "123"; end
     end

--- a/test/unit/strategies/query_parameter_strategy_test.rb
+++ b/test/unit/strategies/query_parameter_strategy_test.rb
@@ -10,6 +10,11 @@ class QueryParameterStrategyTest < ActiveSupport::TestCase
     assert_equal 11, @strategy.extract(request)
   end
 
+  test "a request with an Integer api_version parameter retrieves the version" do
+    request = stub(:query_parameters => {:api_version => 11, :other => 'parameter'})
+    assert_equal 11, @strategy.extract(request)
+  end
+
   test "a request without an api_version parameter returns nil" do
     request = stub(:query_parameters => {:other => 'parameter', :another => 'parameter'})
     assert_nil @strategy.extract(request)


### PR DESCRIPTION
This is a minor thing, but it supports the example usage in the documentation for testing with the query_parameter strategy. I opted to fix it in the strategy instead of calling to_s on the version match in case that had performance or other consequences for other strategies.

``` ruby
BCApi::Application.config.view_versions.each do |supported_version|
   ...
end
```
