### PR TITLE
Version lookups were not including deprecated versions

### DIFF
--- a/lib/versioncake/controller_additions.rb
+++ b/lib/versioncake/controller_additions.rb
@@ -56,7 +56,7 @@ module VersionCake
       end
 
       if VersionCake.config.rails_view_versioning
-        @_lookup_context.versions = version_context.supported_versions.map { |n| :"v#{n}" }
+        @_lookup_context.versions = version_context.available_versions.map { |n| :"v#{n}" }
       end
     end
 

--- a/lib/versioncake/version_context.rb
+++ b/lib/versioncake/version_context.rb
@@ -13,8 +13,8 @@ module VersionCake
 
     # Ordered versions that are equal to or lower
     # than the requested version.
-    def supported_versions
-      @resource.supported_versions.sort.reverse.reject { |v| v > @version }
+    def available_versions
+      @resource.available_versions.reverse.reject { |v| v > @version }
     end
   end
 end

--- a/lib/versioncake/versioned_resource.rb
+++ b/lib/versioncake/versioned_resource.rb
@@ -7,8 +7,12 @@ module VersionCake
         uri, supported_versions, deprecated_versions, obsolete_versions
     end
 
+    def available_versions
+      (@supported_versions.to_a + @deprecated_versions.to_a).sort
+    end
+
     def latest_version
-      @supported_versions.last
+      available_versions.last
     end
   end
 end

--- a/spec/unit/version_context_spec.rb
+++ b/spec/unit/version_context_spec.rb
@@ -6,29 +6,30 @@ describe VersionCake::VersionContext do
         latest_version: 8,
         supported_versions: [5,6,7,8],
         deprecated_versions: [4],
+        available_versions: [4,5,6,7,8],
         obsolete_versions: [2,3]
     )
   end
   let(:result) { :supported }
   subject(:context) { described_class.new(version, resource, result) }
 
-  describe '#supported_versions' do
+  describe '#available_versions' do
     let(:version) { 7 }
 
-    it { expect(context.supported_versions).to eq [7,6,5] }
+    it { expect(context.available_versions).to eq [7,6,5,4] }
 
     context 'for a deprecated version' do
       let(:version) { 4 }
       let(:result) { :deprecated }
 
-      it { expect(context.supported_versions).to eq [] }
+      it { expect(context.available_versions).to eq [4] }
     end
 
     context 'for an obsolete version' do
       let(:version) { 2 }
       let(:result) { :obsolete }
 
-      it { expect(context.supported_versions).to eq [] }
+      it { expect(context.available_versions).to eq [] }
     end
   end
 

--- a/spec/unit/versioned_resource_spec.rb
+++ b/spec/unit/versioned_resource_spec.rb
@@ -4,6 +4,20 @@ describe VersionCake::VersionedResource do
 
   let(:resource) { described_class.new('hello/123', [1,2], [3], [4,5,6])}
 
+  describe '#available_versions' do
+    subject { resource.available_versions }
+
+    it { is_expected.to match_array (3..6).to_a }
+
+    context 'when given out of order' do
+      let(:resource) { described_class.new('hello/123', [1,2], [3], [7,6,4,5])}
+
+      it 'order them' do
+        is_expected.to match_array (3..7).to_a
+      end
+    end
+  end
+
   describe '#latest_version' do
     subject { resource.latest_version }
 


### PR DESCRIPTION
This adds `available_versions` to the resource which is deprecated + supported versions.