### PR TITLE
Fix for api only rails 5 case

### DIFF
--- a/lib/versioncake/controller_additions.rb
+++ b/lib/versioncake/controller_additions.rb
@@ -47,7 +47,7 @@ module VersionCake
       return unless version_context
 
       check_for_version_errors!(version_context.result)
-      configure_rails_view_versioning(version_context)
+      configure_rails_view_versioning(version_context) if @_lookup_context.respond_to?(:versions)
     end
 
     def check_for_version_errors!(result)


### PR DESCRIPTION
Hi there!
When you generate Rails app with --api option, Rails does not assign value to @_lookup_context and it causes the error below
```
NoMethodError (undefined method `versions=' for nil:NilClass):

/foo/.rvm/gems/ruby-2.3.0@rails5-exp/bundler/gems/versioncake-a5304638f8d3/lib/versioncake/controller_additions.rb:71:in `configure_rails_view_versioning'
/foo/.rvm/gems/ruby-2.3.0@rails5-exp/bundler/gems/versioncake-a5304638f8d3/lib/versioncake/controller_additions.rb:50:in `check_version!'
activesupport (5.0.0.beta3) lib/active_support/callbacks.rb:382:in `block in make_lambda'
activesupport (5.0.0.beta3) lib/active_support/callbacks.rb:169:in `block (2 levels) in halting'
actionpack (5.0.0.beta3) lib/abstract_controller/callbacks.rb:12:in `block (2 levels) in <module:Callbacks>'
...
```
This PR fixes issue. (I used respond_to? rather than is_a? ActionView::LookupContext)
(I'm not sure how to test it other than adding a new test_app with api only settings, but if you have any idea I'd be happy to implement it.)
My assumption is version > 3.0 supports rails5 as documented.

Thanks!