### PR TITLE
Avoid Fixnum deprecation warnings in ruby 2.4

### DIFF
--- a/lib/versioncake/strategies/extraction_strategy.rb
+++ b/lib/versioncake/strategies/extraction_strategy.rb
@@ -5,7 +5,7 @@ module VersionCake
 
     def extract(request)
       version = execute(request)
-      if version.is_a?(Fixnum)
+      if version.is_a?(Integer)
         version
       elsif version.is_a?(String) && /[0-9]+/.match(version)
         version.to_i


### PR DESCRIPTION
In ruby 2.4, `Fixnum` and `Bignum` have been merged into a unified `Integer` class. In previous versions there should be no harm in treating them the same (both were `Integer` subclasses), so we might as well just check for `Integer`.

Fixes

```
versioncake-3.2.0/lib/versioncake/strategies/extraction_strategy.rb:8:
  warning: constant ::Fixnum is deprecated
```