### PR TITLE
Fix build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 1.9.2
+  - 1.9.2-p330
   - 1.9.3
   - 2.0.0
   - 2.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 1.9.2
+    - rvm: 1.9.2-p330
       gemfile: gemfiles/rails4.0.gemfile
-    - rvm: 1.9.2
+    - rvm: 1.9.2-p330
       gemfile: gemfiles/rails4.1.gemfile
-    - rvm: 1.9.2
+    - rvm: 1.9.2-p330
       gemfile: gemfiles/rails4.2.gemfile
-    - rvm: 1.9.2
+    - rvm: 1.9.2-p330
       gemfile: gemfiles/rails5.0.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails5.0.gemfile


### PR DESCRIPTION
Um not sure if this will work, but travis build failure says 1.9.3 is
not installed and tries to install it, then fails (Reference build -
https://travis-ci.org/bwillis/versioncake/jobs/229803248).