### PR TITLE
Clean up unused supported_version_numbers

### DIFF
--- a/lib/versioncake/configuration.rb
+++ b/lib/versioncake/configuration.rb
@@ -3,8 +3,6 @@ require 'active_support/core_ext/array/wrap.rb'
 
 module VersionCake
   class Configuration
-
-    SUPPORTED_VERSIONS_DEFAULT = (1..10)
     VERSION_KEY_DEFAULT = 'api_version'
 
     attr_reader :extraction_strategies, :response_strategies, :supported_version_numbers,
@@ -17,7 +15,6 @@ module VersionCake
       @rails_view_versioning         = true
       @missing_version_use_unversioned_template = true
       @default_version = nil
-      self.supported_version_numbers = SUPPORTED_VERSIONS_DEFAULT
       self.extraction_strategy       = [
           :http_accept_parameter,
           :http_header,
@@ -51,27 +48,6 @@ module VersionCake
       Array.wrap(val).each do |configured_strategy|
         @response_strategies << VersionCake::ResponseStrategy::Base.lookup(configured_strategy)
       end
-    end
-
-    def supported_version_numbers=(val)
-      @supported_version_numbers = val.respond_to?(:to_a) ? val.to_a : Array.wrap(val)
-      @supported_version_numbers.sort!.reverse!
-    end
-
-    def supported_versions(requested_version_number=nil)
-      @supported_version_numbers.collect do |supported_version_number|
-        if requested_version_number.nil? || supported_version_number <= requested_version_number
-          :"v#{supported_version_number}"
-        end
-      end
-    end
-
-    def supports_version?(version)
-      @supported_version_numbers.include? version
-    end
-
-    def latest_version
-      @supported_version_numbers.first
     end
 
     def resources

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -1,64 +1,7 @@
 require 'spec_helper'
 
 describe VersionCake::Configuration do
-  let(:supported_versions) { }
-  subject(:config) do
-    config = described_class.new
-    if supported_versions
-      config.supported_version_numbers = supported_versions
-    end
-    config
-  end
-
-  context '#supported_version_numbers' do
-    context 'by default' do
-      let(:supported_versions) { nil }
-
-      it 'is a logical set of version numbers' do
-        expect(config.supported_version_numbers).to eq (1..10).to_a.reverse
-      end
-    end
-
-    context 'when set with a range' do
-      let(:supported_versions) { (1..7) }
-
-      it { expect(config.supported_version_numbers).to eq [7,6,5,4,3,2,1] }
-    end
-
-    context 'when set with an unordered array' do
-      let(:supported_versions) { [2,4,1,5,3,6,7] }
-
-      it { expect(config.supported_version_numbers).to eq [7,6,5,4,3,2,1] }
-    end
-
-    context 'when set with a single value' do
-      let(:supported_versions) { 19 }
-
-      it { expect(config.supported_version_numbers).to eq [19] }
-    end
-  end
-
-  context '#supports_version?' do
-    let(:supported_versions) { (1..7) }
-
-    it 'is true for all supported versions' do
-      config.supported_version_numbers.each do |supported_version|
-        expect(config.supports_version?(supported_version)).to be_truthy
-      end
-    end
-
-    it 'is false for other versions' do
-      [-2,-1,0,8,9,10].each do |unsupported_version|
-        expect(config.supports_version?(unsupported_version)).to be_falsey
-      end
-    end
-  end
-
-  context '#latest_version' do
-    let(:supported_versions) { [4,1,3,9,2,54] }
-
-    it { expect(config.latest_version).to eq 54 }
-  end
+  subject(:config) { described_class.new }
 
   context '#missing_version' do
     before { config.missing_version = 5 }


### PR DESCRIPTION
Fixes #70

`supported_version_numbers` was the conical list of supported versions
until we introduced `VersionedResource` which allows individual
resources to define their version support.

Side note: Red PRs are awesome!