### PR TITLE
don't replace frozen strings

### DIFF
--- a/lib/versioncake/view_additions.rb
+++ b/lib/versioncake/view_additions.rb
@@ -16,7 +16,10 @@ ActionView::PathResolver.class_eval do
                                                      handlers: "."
                                                  })
 
-    ActionView::PathResolver::DEFAULT_PATTERN.replace ":prefix/:action{.:locale,}{.:formats,}{+:variants,}{.:versions,}{.:handlers,}"
+    def initialize(pattern = nil)
+      @pattern = pattern || ":prefix/:action{.:locale,}{.:formats,}{+:variants,}{.:versions,}{.:handlers,}"
+      super()
+    end
   else
     ActionView::PathResolver::EXTENSIONS.replace [:locale, :formats, :versions, :handlers]
 


### PR DESCRIPTION
In rails 5.2 these strings are frozen and you cannot replace them. Overrwriting constants generates warnining but I cannot see how to do it better at the moment