### PR TITLE
Remove more supported_version_numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,10 +397,10 @@ end
 
 ### Testing all supported versions
 
-You can iterate over all of the supported version numbers by accessing the ```AppName::Application.config.versioncake.supported_version_numbers```.
+You can iterate over all of the supported version numbers by accessing the ```VersionCake.config.versioned_resources.first.available_versions```.
 
 ```ruby
-VersionCake.config.resources.first.supported_versions.each do |supported_version|
+VersionCake.config.versioned_resources.first.available_versions.each do |supported_version|
   before do
     @controller.stubs(:request_version).returns(supported_version)
   end
@@ -435,6 +435,7 @@ Thanks to all those who have helped make Version Cake really sweet:
 * [John Hawthorn](https://github.com/jhawthorn)
 * [Ersin Akinci](https://github.com/earksiinni)
 * [Bartosz Bonisławski](https://github.com/bbonislawski)
+* [Harry Lascelles](https://github.com/hlascelles)
 
 # Related Material
 

--- a/lib/versioncake/configuration.rb
+++ b/lib/versioncake/configuration.rb
@@ -5,7 +5,7 @@ module VersionCake
   class Configuration
     VERSION_KEY_DEFAULT = 'api_version'
 
-    attr_reader :extraction_strategies, :response_strategies, :supported_version_numbers,
+    attr_reader :extraction_strategies, :response_strategies,
       :versioned_resources, :default_version, :missing_version_use_unversioned_template
     attr_accessor :missing_version, :version_key, :rails_view_versioning
 


### PR DESCRIPTION
This accessor returns `nil` every time, and the README should be updated.