### PR TITLE
Alter how ControllerAdditions is included in ActionController

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    versioncake (4.0.1)
+    versioncake (4.0.2)
       actionpack (> 5.0)
       activesupport (> 5.0)
       railties (> 5.0)

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    versioncake (4.0.1)
+    versioncake (4.0.2)
       actionpack (> 5.0)
       activesupport (> 5.0)
       railties (> 5.0)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    versioncake (4.0.1)
+    versioncake (4.0.2)
       actionpack (> 5.0)
       activesupport (> 5.0)
       railties (> 5.0)

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    versioncake (4.0.1)
+    versioncake (4.0.2)
       actionpack (> 5.0)
       activesupport (> 5.0)
       railties (> 5.0)

--- a/lib/versioncake.rb
+++ b/lib/versioncake.rb
@@ -26,6 +26,7 @@ if defined?(Rails)
   require 'versioncake/controller_additions'
   require 'versioncake/view_additions'
   require 'versioncake/engine'
+  require 'versioncake/railtie'
 end
 
 module VersionCake
@@ -39,3 +40,4 @@ module VersionCake
     yield self.config
   end
 end
+

--- a/lib/versioncake/controller_additions.rb
+++ b/lib/versioncake/controller_additions.rb
@@ -83,9 +83,3 @@ module VersionCake
     end
   end
 end
-
-ActionController::Base.send(:include, VersionCake::ControllerAdditions)
-
-if defined?(ActionController::API)
-  ActionController::API.send(:include, VersionCake::ControllerAdditions)
-end

--- a/lib/versioncake/railtie.rb
+++ b/lib/versioncake/railtie.rb
@@ -1,0 +1,9 @@
+require 'rails/railtie'
+
+class Railtie < ::Rails::Railtie
+  initializer :versioncake do
+    ActiveSupport.on_load :action_controller do
+      include VersionCake::ControllerAdditions
+    end
+  end
+end

--- a/lib/versioncake/version.rb
+++ b/lib/versioncake/version.rb
@@ -1,3 +1,3 @@
 module VersionCake
-  VERSION = '4.0.1'
+  VERSION = '4.0.2'
 end


### PR DESCRIPTION
Alters how VersionCake::ControllerAdditions is included into ActionController. The original
`ActionController::Base.send(:include, VersionCake::ControllerAdditions)` appears to cause some sort of problem that is causing #76 (why exactly that is I have no idea).

If we include ControllerAdditions using similar methods to other gems I have seen (notably cribbed from Jbuilder), then this appears to fix the problem, while still maintaining compatibility with the older versions of rails.

 * Should fix #76 

(First ever pull request - go easy on me ;-P)