### PR TITLE
Fix parameter order issue in VersionChecker

### DIFF
--- a/lib/versioncake/version_checker.rb
+++ b/lib/versioncake/version_checker.rb
@@ -2,7 +2,8 @@ module VersionCake
   class VersionChecker
     attr_reader :result
     def initialize(version, resource)
-      @version, @resource = resource, version
+      @version = version
+      @resource = resource
     end
 
     def execute

--- a/lib/versioncake/version_context_service.rb
+++ b/lib/versioncake/version_context_service.rb
@@ -43,7 +43,7 @@ module VersionCake
     private
 
     def check_version(resource, version)
-      VersionCake::VersionChecker.new(resource, version).execute
+      VersionCake::VersionChecker.new(version, resource).execute
     end
 
     def find_resource(uri)

--- a/spec/unit/version_checker_spec.rb
+++ b/spec/unit/version_checker_spec.rb
@@ -10,7 +10,7 @@ describe VersionCake::VersionChecker do
   end
   let(:version) { }
   subject do
-    checker = VersionCake::VersionChecker.new(resource, version)
+    checker = VersionCake::VersionChecker.new(version, resource)
     checker.execute
   end
 


### PR DESCRIPTION
I did not change the definition of VersionChecker#initialize b/c I did not want to make a breaking change. Leads to a little bit of funny looking code.

https://github.com/bwillis/versioncake/issues/97